### PR TITLE
feat(automations): add Trigger component and update breadcrumb

### DIFF
--- a/src/app/(protected)/dashboard/[slug]/automations/[id]/page.tsx
+++ b/src/app/(protected)/dashboard/[slug]/automations/[id]/page.tsx
@@ -1,4 +1,6 @@
+import Trigger from '@/components/global/automations/trigger'
 import AutomationBreadCrumb from '@/components/global/bread-crumbs/automations'
+import { CircleAlert } from 'lucide-react'
 import React from 'react'
 
 type Props = {
@@ -12,6 +14,13 @@ const page = ( { params }: Props) => {
   return (
     <div className='flex flex-col items-center gap-y-20'>
       <AutomationBreadCrumb id={params.id}/>
+      <div className='w-full lg:w-10/12 xl:w-6/12 p-5 rounded-xl flex flex-col bg-[#1D1D1D] gap-y-3'>
+        <div className='flex gap-2'>
+          <CircleAlert color='pink'/>
+          When...
+        </div>
+        <Trigger id={params.id} />
+      </div>
     </div>
   )
 }

--- a/src/components/global/automations/trigger/index.tsx
+++ b/src/components/global/automations/trigger/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+type Props = {
+    id: string
+}
+
+const Trigger = ( {id}: Props) => {
+  return (
+    <div>index</div>
+  )
+}
+
+export default Trigger

--- a/src/components/global/bread-crumbs/automations/index.tsx
+++ b/src/components/global/bread-crumbs/automations/index.tsx
@@ -3,9 +3,11 @@ import { ChevronRight, PencilIcon } from 'lucide-react'
 import React from 'react'
 import ActivateAutomationButton from '../../activate-automation-button'
 
-type Props = {}
+type Props = {
+  id: string
+}
 
-const AutomationBreadCrumb = (props: Props) => {
+const AutomationBreadCrumb = ( {id}: Props) => {
 
     //to do get automation data
     //


### PR DESCRIPTION
Introduce a new Trigger component to handle automation triggers and update the AutomationBreadCrumb component to accept an `id` prop. These changes enable the automation details page to display the trigger section and pass the necessary `id` parameter for context.